### PR TITLE
Refactoring the SW

### DIFF
--- a/src/sw.js
+++ b/src/sw.js
@@ -131,7 +131,12 @@ precacheAndRoute(self.__WB_MANIFEST);
 // HTML caching strategy
 const htmlStrategy = new StaleWhileRevalidate({
   cacheName: 'pages-cache',
-  plugins: [navigationNormalizationPlugin],
+  plugins: [
+    navigationNormalizationPlugin,
+    new CacheableResponsePlugin({
+      statuses: [200, 301, 404],
+    }),
+  ],
 });
 
 /**

--- a/src/sw.js
+++ b/src/sw.js
@@ -216,7 +216,7 @@ setCatchHandler(({ event }) => {
   // https://medium.com/dev-channel/service-worker-caching-strategies-based-on-request-types-57411dd7652c
   switch (event.request.destination) {
     case 'document':
-      return caches.match('/404');
+      return caches.match('/404/');
 
     // case 'image':
     //   return matchPrecache(FALLBACK_IMAGE_URL);


### PR DESCRIPTION
A few changes that should leave this SW more general-purpose, while also simplifying some of the logic around navigations.

- Since every navigation (should) be for a HTML document, just set up a route that checks for `mode === 'navigate'` and use that to trigger your HTML logic, rather than explicitly confirming content types or routing based on URLs.

- Moved from using hardcoded `RegExp`s for subresource routes, and instead, use the `request.destination` property to route to the appropriate handler. This might need to be tweaked further if, for instance, certain first-party images/styles/fonts need to be cached differently than third-party ones. But in general, this should make the routes more general-purpose.